### PR TITLE
Parse error. IE8

### DIFF
--- a/js/bootstrap-tabs-x.js
+++ b/js/bootstrap-tabs-x.js
@@ -147,7 +147,7 @@
                         },
                         error: function(request, status, message) {
                              $el.trigger('tabsX.error', [request, status, message]);
-                        },
+                        }
                     });
                     $el.trigger('tabsX.click');
                 });        


### PR DESCRIPTION
Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.