### PR TITLE
Add feature of flushing cache of specific tabs

### DIFF
--- a/js/bootstrap-tabs-x.js
+++ b/js/bootstrap-tabs-x.js
@@ -148,9 +148,22 @@
                 }
             };
         },
-        flushCache: function () {
+        flushCache: function (tabsIds) {
             var self = this;
-            self.cache.data = {};
+            if (typeof tabsIds === 'string'){
+                tabsIds = [tabsIds];
+            }
+            if (typeof tabsIds === 'object' && tabsIds) {
+                Object.values(tabsIds).forEach(function(tabId){
+                    Object.keys(self.cache.data).forEach(function(key){
+                        if(key.endsWith(tabId)){
+                            delete self.cache.data[key];
+                        }
+                    });
+                });
+            } else {
+                self.cache.data = {};
+            }
         }
     };
 


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] New feature

## Changes
Using this for single
`$('#tabs-container').tabsX('flushCache', '#tabId');`
or this for multiple tabs
`$('#tabs-container').tabsX('flushCache', ['#tabId1', '#tabId2', '#tabId3', ...]);`
I have added the feature to flush only specific tabs.
eg. 
In this way if you are using  a modal and you are filling a form in the first tab and then in the second tab you did some changes trough ajax and you need to reload it you will not lose not already saved change in the first one.