### PR TITLE
Change to make icons before labels work

### DIFF
--- a/css/bootstrap-tabs-x-bs4.css
+++ b/css/bootstrap-tabs-x-bs4.css
@@ -97,9 +97,8 @@
 }
 
 .tabs-left > .nav-tabs .nav-item .nav-link :before, .tabs-right > .nav-tabs .nav-item .nav-link :before {
-    position: absolute;
+    position: relative;
     height: 100%;
-    content: " ";
     width: 1px;
     border-color: rgba(0,0,0,.15) #fff;
 }


### PR DESCRIPTION
e.g. awesome icons won't work caused by the before tag content: " "

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

css adjustment

## Related Issues
If this is related to an existing ticket, include a link to it as well.