### PR TITLE
Update bootstrap-tabs-x.js

### DIFF
--- a/js/bootstrap-tabs-x.js
+++ b/js/bootstrap-tabs-x.js
@@ -127,7 +127,6 @@
                     }
                     settings = $.extend(true, {}, {
                         type: 'post',
-                        dataType: 'json',
                         url: vUrl,
                         beforeSend: function (jqXHR, settings) {
                             $tab.html('<br><br><br>');


### PR DESCRIPTION
Jquery get crashed when try to parse html data to JSON

## Scope
This pull request includes a

- [x] Bug fix

## Changes
The following changes were made

- Deleted dataType property from ajax query on tab click